### PR TITLE
prevent empty mysql lookup entries

### DIFF
--- a/src/Http/Controllers/Admin/XlsformTemplateCrudController.php
+++ b/src/Http/Controllers/Admin/XlsformTemplateCrudController.php
@@ -91,10 +91,18 @@ class XlsformTemplateCrudController extends CrudController
             [
                 'name' => 'mysql_name',
                 'label' => 'MySQL Table Name',
+                'validationRules' => 'required',
+                'validationMessages' => [
+                    'required' => 'Please add the name of the MySQL view that holds the data for the CSV file.',
+                ]
             ],
             [
                 'name' => 'csv_name',
                 'label' => 'CSV File Name',
+                'validationRules' => 'required',
+                'validationMessages' => [
+                    'required' => 'Please add the name of the CSV file that should be attached to the ODK form.',
+                ]
             ],
             [
                 'name' => 'per_owner',

--- a/src/Models/XlsformTemplate.php
+++ b/src/Models/XlsformTemplate.php
@@ -31,10 +31,17 @@ class XlsformTemplate extends Model
         $this->uploadFileWithNames($value, 'xlsfile', config('odk-link.storage.xlsforms'), '');
     }
 
+    public function setCsvLookupsAttribute($value): void
+    {
+        // filter out any entries where mysql_name === null and csv_name === null
+        // these are assumed to be unused entries where the user simply did not remove them.
+        $this->attributes['csv_lookups'] = collect($value)->filter(fn($entry) => $entry['mysql_name'] && $entry['csv_name'])->toJson();
+    }
+
     public function setMediaAttribute($value): void
     {
 
-        if(is_array($value)){
+        if (is_array($value)) {
             $value = json_encode($value);
         }
 
@@ -78,11 +85,11 @@ class XlsformTemplate extends Model
     {
         $request = request();
 
-        if(!$request) {
+        if (!$request) {
             return;
         }
 
-        if (! is_array($this->{$attribute_name})) {
+        if (!is_array($this->{$attribute_name})) {
             $attribute_value = json_decode($this->{$attribute_name}, true) ?? [];
         } else {
             $attribute_value = $this->{$attribute_name};
@@ -116,4 +123,6 @@ class XlsformTemplate extends Model
 
         $this->attributes[$attribute_name] = json_encode($attribute_value);
     }
+
+
 }


### PR DESCRIPTION
Fixes issue on the FAW platform. 

- xlsform templates with "empty" mysql_lookup entries will cause an error whenever a new xlsform is created. On the FAW platform, new forms are created for each team as soon as the team is created, so this error currently appears whenever a new team is created. 

