### PR TITLE
Submission scoping

### DIFF
--- a/src/Http/Controllers/Admin/SubmissionCrudController.php
+++ b/src/Http/Controllers/Admin/SubmissionCrudController.php
@@ -13,6 +13,7 @@ use Exception;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use JsonException;
 use Stats4sd\OdkLink\Jobs\ProcessSubmission;
@@ -41,6 +42,7 @@ class SubmissionCrudController extends CrudController
         CRUD::setModel(Submission::class);
         CRUD::setRoute(config('backpack.base.route_prefix') . '/submission');
         CRUD::setEntityNameStrings('submission', 'submissions');
+
     }
 
     /**
@@ -93,9 +95,9 @@ class SubmissionCrudController extends CrudController
         $this->setupListOperation();
 
         CRUD::column('content')->type('custom_html')->value(
-            /**
-             * @throws JsonException
-             */
+        /**
+         * @throws JsonException
+         */
             function ($entry) {
                 if (!is_array($entry->content)) {
                     $content = json_decode($entry->content, true, 512, JSON_THROW_ON_ERROR);

--- a/src/Http/Controllers/Admin/XlsformCrudController.php
+++ b/src/Http/Controllers/Admin/XlsformCrudController.php
@@ -44,10 +44,6 @@ class XlsformCrudController extends CrudController
 
 
         // if the current user is an xlsform-admin (role defined in the config), then show all xlsforms. Otherwise, show only the ones that the user has access to:
-
-        if (Auth::check() && !Auth::user()?->hasRole(config('odk-link.roles.xlsform-admin'))) {
-            CRUD::addClause('owned');
-        }
     }
 
     /**
@@ -121,7 +117,7 @@ class XlsformCrudController extends CrudController
 
     public function archiveForm(Xlsform $xlsform, OdkLinkService $odkLinkService): Response
     {
-        if (!xlsform->is_active) {
+        if (!$xlsform->is_active) {
             return response([
                 "type" => "warning",
                 "message" => "The form is currently not active"

--- a/src/Models/Submission.php
+++ b/src/Models/Submission.php
@@ -3,10 +3,13 @@
 
 namespace Stats4sd\OdkLink\Models;
 
+use App\Models\User;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
 
 class Submission extends Model
 {
@@ -23,10 +26,44 @@ class Submission extends Model
         'entries' => 'array',
     ];
 
+    protected static function booted()
+    {
+        parent::booted();
+
+        static::addGlobalScope('owned', function (Builder $query) {
+            if (Auth::check() && !Auth::user()?->hasRole(config('odk-link.roles.xlsform-admin'))) {
+                $query->where(function (Builder $query) {
+                    $query->whereHas('xlsformVersion', function (Builder $query) {
+                        $query->whereHas('xlsform', function (Builder $query) {
+                            $query->whereHas('owner', function (Builder $query) {
+
+                                //if xlsforms are owned by a user, return the user's forms directly.
+
+                                if (is_a($query->getModel(), User::class)) {
+                                    $query->where('users.id', Auth::id());
+                                } else {
+                                    // is the xlsform owned by a team/group that the logged-in user is linked to?
+                                    $query->whereHas('users', function ($query) {
+                                        $query->where('users.id', Auth::id());
+                                    });
+                                }
+                            });
+                        });
+                    });
+                });
+            }
+        });
+    }
+
+    public function scopeOwned(Builder $builder): void
+    {
+
+    }
+
 
     // $this->entries is an array of every Model entry created as a result of processing this submission.
     // This helper function makes it easy to update this array.
-    public function addEntry(String $model, array $ids): void
+    public function addEntry(string $model, array $ids): void
     {
         $value = $this->entries;
 

--- a/src/Models/Xlsform.php
+++ b/src/Models/Xlsform.php
@@ -15,12 +15,14 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use JsonException;
 use Maatwebsite\Excel\Facades\Excel;
 use Stats4sd\OdkLink\Exports\OdkSubmissionContentExport;
 use Stats4sd\OdkLink\Jobs\UpdateXlsformTitleInFile;
 use App\Models\User;
 use Stats4sd\OdkLink\OdkLink;
 use Stats4sd\OdkLink\Services\OdkLinkService;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class Xlsform extends Model
 {
@@ -62,7 +64,7 @@ class Xlsform extends Model
 
     }
 
-    public function scopeOwned($builder)
+    public function scopeOwned($builder): void
     {
         if (Auth::check()) {
             $builder->where(function ($query) {
@@ -124,7 +126,7 @@ class Xlsform extends Model
     }
 
 
-    public function getCurrentVersionAttribute()
+    public function getCurrentVersionAttribute(): ?string
     {
         return $this->xlsformVersions()
             ->where('active', 1)
@@ -185,7 +187,7 @@ class Xlsform extends Model
 
     /**
      * Method to retrieve the encoded settings for the current draft version on ODK Central
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function getDraftQrCodeStringAttribute(): ?string
     {
@@ -227,7 +229,7 @@ class Xlsform extends Model
 
     }
 
-    public function exportSubmissionData()
+    public function exportSubmissionData(): BinaryFileResponse
     {
         return Excel::download(new OdkSubmissionContentExport($this), 'test.xlsx');
     }


### PR DESCRIPTION
PR to add query scopes to submissions as well as xlsforms.

 - Both the Submission and Xlsform models now have a Global Scope called "owned". This scope checks if the user is a site admin, and if not will filter to only show submissions/forms owned by the user (or by a team/group that the user is related to). 
 - I moved the existing local scope on Xlsform to be global, as I think this makes sense to be the default everywhere across the application. 

